### PR TITLE
Support native object type

### DIFF
--- a/test.js
+++ b/test.js
@@ -109,11 +109,29 @@ tap.test('lazy', t => {
     t.end();
   });
 
+  t.test('object', t => {
+    // Create a lazy object.
+    let fooCalled = false;
+    const obj = {
+      foo: () => fooCalled = true
+    };
+    const lazyObj = dude.lazy(obj);
+    // Properties are maintained.
+    t.equal(fooCalled, false);
+    // Call the lazy method to get the task.
+    const task = lazyObj.foo();
+    t.equal(fooCalled, false);
+    // Run the task.
+    task.run();
+    t.equal(fooCalled, true);
+    t.end();
+  });
+
   t.test('object instance', t => {
     // Create a lazy instance.
     const obj = new TestClass();
     const lazyObj = dude.lazy(obj);
-    // Property are maintained.
+    // Properties are maintained.
     t.equal(obj.fooCalled, false);
     // Call the lazy method to get the task.
     const task = lazyObj.foo();

--- a/thedude.js
+++ b/thedude.js
@@ -41,10 +41,10 @@ function makeLazy(funcOrObj, createTask) {
   const instance = {};
   let proto = null;
   if (funcOrObj.constructor.name === 'Object') {
-    // If a raw object was provided.
+    // A raw object was provided.
     proto = funcOrObj;
   } else {
-    // It's an instance of another constructor.
+    // An instance of another constructor was provided.
     proto = Object.getPrototypeOf(funcOrObj);
   }
   Object.getOwnPropertyNames(proto).forEach(name => {
@@ -313,7 +313,7 @@ class TaskList {
     When the function is executed, the corresponding task is automatically
     added to this task list.
 
-    @param {Object or Function} funcOrObj The original function or
+    @param {Object or Function} funcOrObj The original function, raw object or
       instance to decorate so that it becomes lazy. Being lazy means that the
       function itself (or all object methods, when an instance is provided)
       returns a task rather than actually execute its body.


### PR DESCRIPTION
When stubbing out instances it's common to pass a native object type as mocks. This adds support for native object types while maintaining compatibility with functions and instances.